### PR TITLE
Updating negroni to use latest import path.

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -55,7 +55,7 @@ func NewMiddleware(name string, buckets ...float64) *Middleware {
 func (m *Middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	start := time.Now()
 	next(rw, r)
-	res := rw.(negroni.ResponseWriter)
+	res := negroni.NewResponseWriter(rw)
 	m.reqs.WithLabelValues(http.StatusText(res.Status()), r.Method, r.URL.Path).Inc()
 	m.latency.WithLabelValues(http.StatusText(res.Status()), r.Method, r.URL.Path).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
 }


### PR DESCRIPTION
Couldn't do the response casting because of a missing `Before()` method so I've updated how the negroni response writer is made.

Also the codegansta is the old repositories so just updating to reflect that
